### PR TITLE
Avoidbinding

### DIFF
--- a/AtomicAction.js
+++ b/AtomicAction.js
@@ -4,67 +4,22 @@
 
 var QUESTIFY = (function (QUESTIFY) {
 	"use strict";
-	function createAtomicAction (conditions) {
-		var that = {},
-			started = false,
-			finished = false;
+	function createAtomicAction (conditionFunctions) {
+		var that = {};
 
-		that.conditions = conditions;
+		that.conditions = conditionFunctions;
 
-		that.start = function () {
-			started = true;
-		};
-
-		that.forceFinish = function () {
-			finished = true;
-		};
-
-		that.isStarted = function () {
-			return started === true;
-		};
-
-		that.isFinished = function () {
-			return finished === true;
-		};
-
-		that.update = function() {
-			finished = true;
-
-			if (!this.isStarted()) { this.start(); }
+		that.update = function(conditionArrArr) {
+			var finished = true;
 
 			for (var c = 0, cl = this.conditions.length; c < cl; c++) {
-				if (this.conditions[c]() !== true) {
+				if (this.conditions[c].apply(this, conditionArrArr[c]) !== true) {
 					finished = false;
+					return;
 				}
 			}
 
 			return finished;
-		};
-
-		that.withArguments = function(conditionArguments) {
-			var newValue = {};
-
-			//Rebinding the conditions creates new functions,
-			//guaranteeing we aren't going to overwrite functions
-			newValue.conditions = (function (bindTo, conditionsArg) {
-				var boundConditions = [];
-				for (var c = 0, cl = conditionsArg.length; c < cl; c++) {
-					boundConditions.push(conditionsArg[c].bind(bindTo));
-				}
-				return boundConditions;
-			}(this, this.conditions));
-
-			newValue.start = this.start;
-			newValue.forceFinish = this.forceFinish;
-			newValue.isStarted = this.isStarted;
-			newValue.isFinished = this.isFinished;
-			newValue.update = this.update;
-			newValue.started = false;
-			newValue.finished = false;
-
-			newValue.conditionArguments = conditionArguments;
-
-			return newValue;
 		};
 
 		return that;

--- a/Quest.js
+++ b/Quest.js
@@ -4,28 +4,30 @@
 
 var QUESTIFY = (function (QUESTIFY) {
 	"use strict";
-	function createQuest (actions, variables) {
+	function createQuest (actions, argumentsArr) {
 		var that = {},
-			finished = false;
+			finishedMap = new Array(actions.length);
 
-		that.variables = variables;
+		(function initializeFinishedMap() {
+			for (var i = 0, il = finishedMap.length; i < il; i++) {
+				finishedMap[i] = false;
+			}
+		}());
+
+		that.actions = actions;
+		that.argumentsArr = argumentsArr;
 
 		that.updateState = function() {
-			var action,
-				anyUnfinished = false;
+			var action;
 			for (var a = 0, al = actions.length; a < al; a++) {
 				action = actions[a];
-				if (!action.isFinished()) {
-					action.update();
-					if (!action.isFinished()) {
-						anyUnfinished = true;
-					}
+				if (finishedMap[a] === false) {
+					finishedMap[a] = (action.update(argumentsArr[a]) === true);
 				}
 			}
-
-			finished = !anyUnfinished;
 		};
-		that.isFinished = function() { return finished; };
+
+		that.isFinished = function() { return finishedMap.indexOf(false) === -1; };
 
 		return that;
 	}

--- a/Strategy.js
+++ b/Strategy.js
@@ -4,11 +4,10 @@
 
 var QUESTIFY = (function (QUESTIFY) {
 	"use strict";
-	function createStrategy (actions) {
+	function createStrategy (actionsAndArgsObjsArr) {
 		var that = {};
-		actions = actions || [];
 
-		that.actions = actions;
+		that.actionsAndArgs = actionsAndArgsObjsArr;
 
 		return that;
 	}

--- a/UserTest/TestQuestDefinitions.js
+++ b/UserTest/TestQuestDefinitions.js
@@ -79,21 +79,26 @@ var char = USERTEST.createNPCBase(),
 
 (function createStrategies(){
 	questGen.strategies.killEnemy =
-		QUESTIFY.createStrategy([questGen.atomicActions.goto.withArguments([["DEF:pc", "ENEMY:enemy:location"]]),
-								 questGen.atomicActions.kill.withArguments([["DEF:pc", "ENEMY:enemy:location"], ["ENEMY:enemy"]]),
-								 questGen.atomicActions.goto.withArguments([["DEF:pc", "DEF:start"]]),
-								 questGen.atomicActions.report.withArguments([["DEF:giver", "DEF:pc:location"], ["DEF:giver", "ENEMY:enemy"]])]);
+		QUESTIFY.createStrategy([
+			{atomicAction: 'goto',   actionArgs: [["DEF:pc", "ENEMY:enemy:location"]]},
+			{atomicAction: 'kill',   actionArgs: [["DEF:pc", "ENEMY:enemy:location"], ["ENEMY:enemy"]]},
+			{atomicAction: 'goto',   actionArgs: [["DEF:pc", "DEF:start"]]},
+			{atomicAction: 'report', actionArgs: [["DEF:giver", "DEF:pc:location"], ["DEF:giver", "ENEMY:enemy"]]}]);
+
 	questGen.strategies.explore =
-		QUESTIFY.createStrategy([questGen.atomicActions.goto.withArguments([["DEF:pc", "LOC:poi"], ["DEF:pc", "LOC:poi"]]),
-								 questGen.atomicActions.goto.withArguments([["DEF:pc", "DEF:start"], ["DEF:pc", "DEF:start"]])]);
+		QUESTIFY.createStrategy([
+			{atomicAction: 'goto',   actionArgs: [["DEF:pc", "LOC:poi"], ["DEF:pc", "LOC:poi"]]},
+			{atomicAction: 'goto',   actionArgs: [["DEF:pc", "DEF:start"], ["DEF:pc", "DEF:start"]]}]);
+
 	questGen.strategies.goAndLearn =
-		QUESTIFY.createStrategy([questGen.atomicActions.goto.withArguments([["DEF:pc", "NPC:otherNPC:location"], ["DEF:pc:location", "NPC:otherNPC:location"]]),
-								 questGen.atomicActions.listen.withArguments([["DEF:pc", "LOC:locInfo"]])]);
+		QUESTIFY.createStrategy([
+			{atomicAction: 'goto',   actionArgs: [["DEF:pc", "NPC:otherNPC:location"], ["DEF:pc:location", "NPC:otherNPC:location"]]},
+			{atomicAction: 'listen', actionArgs: [["DEF:pc", "LOC:locInfo"]]}]);
 }());
 
 (function createMotivations(){
 	questGen.motivations.reputation = QUESTIFY.createMotivation([questGen.strategies.killEnemy]);
-	questGen.motivations.knowledge = QUESTIFY.createMotivation([questGen.strategies.explore]);
+	questGen.motivations.knowledge = QUESTIFY.createMotivation([questGen.strategies.explore, questGen.strategies.goAndLearn]);
 }());
 
 function noSharedStateTest() {


### PR DESCRIPTION
Reworked to avoid the difficulty related to binding condition functions and it's constant hiccups related to shared state. 

Now, actions are passed an array of arrays of arguments that is then .apply()'d to the condition functions. We only need one instance of an action hanging around and it can be used with a variety of arguments. 

With this, Quest objects are now in charge of quest data targets, as well as tracking the completion state of it's actions. 

Had to do a big rework of the generateQuest function to get this to work, but it actually made that function much simpler and less error prone I believe.
