### PR TITLE
Questdescriptions

### DIFF
--- a/Quest.js
+++ b/Quest.js
@@ -38,8 +38,27 @@ var QUESTIFY = (function (QUESTIFY) {
 			return (finishedMap.length !== 0) ? finishedCount/finishedMap.length : 0;
 		}
 
-		that.actions = actions;
-		that.argumentsArr = argumentsArr;
+		function getActionDescription(actionNumber) {
+			if (actionNumber < descriptions.length && actionNumber >= 0) {
+				return descriptions[actionNumber];
+			}
+
+			return "";
+		}
+
+		function setActionDescription(actionNumber, description) {
+			if (actionNumber < descriptions.length && actionNumber >= 0) {
+				description[actionNumber] = description;
+			}
+		}
+
+		function getActionStatus(actionNumber) {
+			if (actionNumber < finishedMap.length && actionNumber >= 0) {
+				return finishedMap[actionNumber];
+			}
+
+			return false;
+		}
 
 		that.updateState = function() {
 			var action;
@@ -60,6 +79,8 @@ var QUESTIFY = (function (QUESTIFY) {
 		that.completionPercentage = completionPercentage;
 		that.actionFinishedCallback = actionFinishedCallback;
 		that.questFinishedCallback = questFinishedCallback;
+		that.getActionDescription = getActionDescription;
+		that.setActionDescription = setActionDescription;
 
 		return that;
 	}

--- a/Quest.js
+++ b/Quest.js
@@ -4,7 +4,7 @@
 
 var QUESTIFY = (function (QUESTIFY) {
 	"use strict";
-	function createQuest (actions, argumentsArr) {
+	function createQuest (strategy, actions, argumentsArr, descriptions) {
 		var that = {},
 			finishedMap = new Array(actions.length),
 			actionFinishedCallback = function () {},
@@ -75,6 +75,8 @@ var QUESTIFY = (function (QUESTIFY) {
 			if (isFinished()) { reportQuestFinished(); }
 		};
 
+		that.actions = actions;
+		that.strategy = strategy;
 		that.isFinished = isFinished;
 		that.completionPercentage = completionPercentage;
 		that.actionFinishedCallback = actionFinishedCallback;

--- a/Quest.js
+++ b/Quest.js
@@ -83,6 +83,7 @@ var QUESTIFY = (function (QUESTIFY) {
 		that.questFinishedCallback = questFinishedCallback;
 		that.getActionDescription = getActionDescription;
 		that.setActionDescription = setActionDescription;
+		that.getActionStatus = getActionStatus;
 
 		return that;
 	}

--- a/Strategy.js
+++ b/Strategy.js
@@ -4,11 +4,11 @@
 
 var QUESTIFY = (function (QUESTIFY) {
 	"use strict";
-	function createStrategy (variableDefinitions, actionsAndArgsObject) {
+	function createStrategy (variableDefinitions, actionsObjects) {
 		var that = {};
 
 		that.variableDefinitions = variableDefinitions;
-		that.actionsAndArgs = actionsAndArgsObject;
+		that.actionsObjects = actionsObjects;
 
 		return that;
 	}

--- a/UserTest/TestQuestDefinitions.js
+++ b/UserTest/TestQuestDefinitions.js
@@ -95,9 +95,12 @@ var char = USERTEST.createNPCBase("Player Character"),
 (function createStrategies(){
 	questGen.strategies.killEnemy =
 		QUESTIFY.createStrategy(["[ENEMY]:'enemy'"],
-			[{atomicAction: 'goto',   actionArgs: [["pc", "enemy:location"]]},
-			 {atomicAction: 'kill',   actionArgs: [["pc", "enemy:location"], ["enemy"]]},
-			 {atomicAction: 'report', actionArgs: [["pc", "giver:location"], ["giver", "enemy"]]}]);
+			[{atomicAction: 'goto',   actionArgs: [["pc", "enemy:location"]],
+				 description: "Go to [enemy:location:name]"},
+			 {atomicAction: 'kill',   actionArgs: [["pc", "enemy:location"], ["enemy"]],
+				 description: "Kill [enemy:name], mercilessly"},
+			 {atomicAction: 'report', actionArgs: [["pc", "giver:location"], ["giver", "enemy"]],
+				 description: "Report back to [giver:name]"}]);
 
 	questGen.strategies.explore =
 		QUESTIFY.createStrategy(["[LOC]:'poi'"],
@@ -138,6 +141,7 @@ function noSharedStateTest() {
 	npc1.location = loc1;
 	char.location = loc1;
 	enemy1.location = loc2;
+	enemy2.location = loc2;
 
 	char.knownInformation.push(loc1);
 	char.knownInformation.push(loc2);
@@ -315,3 +319,25 @@ function obtainLuxuriesTest() {
 	console.log(quest.isFinished());
 }
 obtainLuxuriesTest();
+
+function descriptionTest() {
+	char = USERTEST.createNPCBase("Player Character");
+	npc1 = USERTEST.createNPCBase("Ivan Idorshed");
+	enemy1 = USERTEST.createNPCBase("Kane");
+	loc1 = USERTEST.createLocationBase("1:1", "Quest Start Location");
+	loc2 = USERTEST.createLocationBase("2:2", "The Forded Hilltop");
+
+	npc1.motivations.push(questGen.motivations.reputation);
+
+	char.location = loc1;
+	npc1.location = loc1;
+	enemy1.location = loc2;
+
+	var quest = questGen.generateQuest(char, npc1, {NPC: [], ENEMY: [enemy1], LOC: [loc2], OBJ: []}, questGen.strategies.killEnemy);
+
+	console.log(quest.getDescription(0));
+	console.log(quest.getDescription(1));
+	console.log(quest.getDescription(2));
+	console.log(quest.getDescription(3));
+}
+descriptionTest();


### PR DESCRIPTION
Added the ability for users to assign a description to an action during strategy creation. This is then parsed in the quest generator, and then maintained and accessible via the Quest object..
